### PR TITLE
refactor: move org tags to categories to tags step

### DIFF
--- a/workflows/this-is-angular-rss.yml
+++ b/workflows/this-is-angular-rss.yml
@@ -12,18 +12,20 @@ jobs:
         id: categories-to-tag
         env:
           categories: ${{ on.rss.outputs.categories }}
+          TIA_HASHTAG: ${{ secrets.TIA_HASHTAG }}
         with:
           script: |
             if(!process.env?.categories) {
-              return "";
+              return `${process.env.TIA_HASHTAG}`;
             }
-            return process.env.categories.split(",").map(t => `#${t}`).join(" ");
+            const categoriesHashTags = process.env.categories.split(",").map(t => `#${t}`).join(" ");
+            return `${categoriesHashTags} ${process.env.TIA_HASHTAG}`;
           result-encoding: string
       - name: Post To This is Angular
         uses: ethomson/send-tweet-action@v1
         with:
           status: |            
-            "${{ on.rss.outputs.title }}" by ${{ on.rss.outputs.author }} ${{steps.categories-to-tag.outputs.result}} ${{ secrets.TIL_HASHTAG }}
+            "${{ on.rss.outputs.title }}" by ${{ on.rss.outputs.author }} ${{steps.categories-to-tag.outputs.result}}
             ${{ on.rss.outputs.link }}
           consumer-key: ${{ secrets.TIA_TWITTER_CONSUMER_KEY }}
           consumer-secret: ${{ secrets.TIA_TWITTER_CONSUMER_SECRET }}

--- a/workflows/this-is-learning-rss.yml
+++ b/workflows/this-is-learning-rss.yml
@@ -12,12 +12,14 @@ jobs:
         id: categories-to-tag
         env:
           categories: ${{ on.rss.outputs.categories }}
+          TIL_HASHTAG: ${{ secrets.TIL_HASHTAG }}
         with:
           script: |
             if(!process.env?.categories) {
-              return "";
+              return `${process.env.TIL_HASHTAG}`;
             }
-            return process.env.categories.split(",").map(t => `#${t}`).join(" ");
+            const categoriesHashTag = process.env.categories.split(",").map(t => `#${t}`).join(" ");
+            return `${categoriesHashTag} ${process.env.TIL_HASHTAG}`;
           result-encoding: string 
       - name: Post to This is Learning
         uses: ethomson/send-tweet-action@v1


### PR DESCRIPTION
In this step, categories to tags, categories are converted into has tags, so we will append the organization tags here, passing them in as environment variables.