### PR TITLE
fix: add hashtags and author to tweet

### DIFF
--- a/workflows/this-is-angular-rss.yml
+++ b/workflows/this-is-angular-rss.yml
@@ -64,6 +64,7 @@ jobs:
           result-encoding: string
           script: |
             const { author_name: authorName, twitter_username: twitterUsername } = process.env;
+            twitterUsername = twitterUsername === "null" ? null : twitterUserName;
 
             return twitterUsername ? `@${twitterUsername}` : authorName;
       - name: Post to This is Angular

--- a/workflows/this-is-angular-rss.yml
+++ b/workflows/this-is-angular-rss.yml
@@ -67,14 +67,11 @@ jobs:
             twitterUsername = twitterUsername === "null" ? null : twitterUserName;
 
             return twitterUsername ? `@${twitterUsername}` : authorName;
-      - name: Post to This is Angular
+      - name: Tweet through This is Angular
         uses: ethomson/send-tweet-action@v1
-        env:
-          author: ${{ steps.author.outputs.result }}
-          hashtags: ${{ steps.hashtags.outputs.result }}
         with:
           status: |
-            "${{ on.rss.outputs.title }}" by ${{ env.author }} ${{ env.hashtags }} #ThisIsAngular
+            "${{ on.rss.outputs.title }}" by ${{ steps.author.outputs.result }} ${{ steps.hashtags.outputs.result }} #ThisIsAngular
             ${{ on.rss.outputs.link }}
           consumer-key: ${{ secrets.TIA_TWITTER_CONSUMER_KEY }}
           consumer-secret: ${{ secrets.TIA_TWITTER_CONSUMER_SECRET }}

--- a/workflows/this-is-learning-rss.yml
+++ b/workflows/this-is-learning-rss.yml
@@ -67,14 +67,11 @@ jobs:
             twitterUsername = twitterUsername === "null" ? null : twitterUserName;
 
             return twitterUsername ? `@${twitterUsername}` : authorName;
-      - name: Post to This is Learning
+      - name: Tweet through This is Learning
         uses: ethomson/send-tweet-action@v1
-        env:
-          author: ${{ steps.author.outputs.result }}
-          hashtags: ${{ steps.hashtags.outputs.result }}
         with:
           status: |
-            "${{ on.rss.outputs.title }}" by ${{ env.author }} ${{ env.hashtags }} #ThisIsLearning
+            "${{ on.rss.outputs.title }}" by ${{ steps.author.outputs.result }} ${{ steps.hashtags.outputs.result }} #ThisIsLearning
             ${{ on.rss.outputs.link }}
           consumer-key: ${{ secrets.TIL_TWITTER_CONSUMER_KEY }}
           consumer-secret: ${{ secrets.TIL_TWITTER_CONSUMER_SECRET }}

--- a/workflows/this-is-learning-rss.yml
+++ b/workflows/this-is-learning-rss.yml
@@ -64,6 +64,7 @@ jobs:
           result-encoding: string
           script: |
             const { author_name: authorName, twitter_username: twitterUsername } = process.env;
+            twitterUsername = twitterUsername === "null" ? null : twitterUserName;
 
             return twitterUsername ? `@${twitterUsername}` : authorName;
       - name: Post to This is Learning


### PR DESCRIPTION
- Handle authors without Twitter username
- Interpolate hashtags and author in tweet `status` instead of through environment variables