### PR TITLE
ci: prevent workflow from being diabled due to repo inactivity

### DIFF
--- a/.github/workflows/actionsflow.yml
+++ b/.github/workflows/actionsflow.yml
@@ -40,3 +40,5 @@ jobs:
           version: 0.2.26
       - name: Run act
         run: act --workflows ./dist/workflows --secret-file ./dist/.secrets --eventpath ./dist/event.json --env-file ./dist/.env -P ubuntu-latest=actionsflow/act-environment:v1 -P ubuntu-18.04=actionsflow/act-environment:v1
+      - name: Prevent workflow from being disabled due to repo inactivity
+        uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
Scheduled GitHub workflows are disabled when there has been no activity in a GitHub repo for 60 days or more.

https://github.com/gautamkrishnar/keepalive-workflow prevents this by pushing a dummy commit every 50 days.