### PR TITLE
ci: update GitHub Actions

### DIFF
--- a/.github/workflows/actionsflow-reset-cache.yml
+++ b/.github/workflows/actionsflow-reset-cache.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Reset Actionsflow Cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Actionsflow Clean
         uses: actionsflow/actionsflow-action@v1
         with:

--- a/.github/workflows/actionsflow-update-dependencies.yml
+++ b/.github/workflows/actionsflow-update-dependencies.yml
@@ -5,7 +5,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Checkout Branch

--- a/.github/workflows/actionsflow-upgrade-actionsflow.yml
+++ b/.github/workflows/actionsflow-upgrade-actionsflow.yml
@@ -7,7 +7,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Checkout Branch

--- a/.github/workflows/actionsflow.yml
+++ b/.github/workflows/actionsflow.yml
@@ -27,7 +27,7 @@ jobs:
     name: Run
     concurrency: actionsflow
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Actionsflow
         uses: actionsflow/actionsflow-action@v1
         with:

--- a/.github/workflows/actionsflow.yml
+++ b/.github/workflows/actionsflow.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup act
         uses: actionsflow/setup-act-for-actionsflow@v1
         with:
-          version: 0.2.26
+          version: 0.2.32
       - name: Run act
         run: act --workflows ./dist/workflows --secret-file ./dist/.secrets --eventpath ./dist/event.json --env-file ./dist/.env -P ubuntu-latest=actionsflow/act-environment:v1 -P ubuntu-18.04=actionsflow/act-environment:v1
       - name: Prevent workflow from being disabled due to repo inactivity

--- a/workflows/this-is-angular-rss.yml
+++ b/workflows/this-is-angular-rss.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RSS categories to hashtags
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         id: hashtags
         env:
           categories: ${{ toJSON(on.rss.outputs.categories) }}
@@ -22,7 +22,7 @@ jobs:
         id: article_endpoint
         env:
           article_url: ${{ on.rss.outputs.link }}
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         with:
           result-encoding: string
           script: |
@@ -33,7 +33,7 @@ jobs:
         with:
           url: ${{ steps.article_endpoint.outputs.result }}
       - name: Twitter username
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         id: twitter_username
         env:
           response: ${{ steps.article_metadata.outputs.data }}
@@ -45,7 +45,7 @@ jobs:
             return response.user.twitter_username;
       - name: Author name from RSS
         id: author_name
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         env:
           rss: ${{ toJSON(on.rss.outputs) }}
         with:
@@ -55,7 +55,7 @@ jobs:
 
             return rss["dc:creator"];
       - name: Author
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         id: author
         env:
           author_name: ${{ steps.author_name.outputs.result }}

--- a/workflows/this-is-angular-rss.yml
+++ b/workflows/this-is-angular-rss.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RSS categories to hashtags
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         id: hashtags
         env:
           categories: ${{ toJSON(on.rss.outputs.categories) }}
@@ -22,7 +22,7 @@ jobs:
         id: article_endpoint
         env:
           article_url: ${{ on.rss.outputs.link }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         with:
           result-encoding: string
           script: |
@@ -33,7 +33,7 @@ jobs:
         with:
           url: ${{ steps.article_endpoint.outputs.result }}
       - name: Twitter username
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         id: twitter_username
         env:
           response: ${{ steps.article_metadata.outputs.data }}
@@ -45,7 +45,7 @@ jobs:
             return response.user.twitter_username;
       - name: Author name from RSS
         id: author_name
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         env:
           rss: ${{ toJSON(on.rss.outputs) }}
         with:
@@ -55,7 +55,7 @@ jobs:
 
             return rss["dc:creator"];
       - name: Author
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         id: author
         env:
           author_name: ${{ steps.author_name.outputs.result }}

--- a/workflows/this-is-learning-rss.yml
+++ b/workflows/this-is-learning-rss.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RSS categories to hashtags
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         id: hashtags
         env:
           categories: ${{ toJSON(on.rss.outputs.categories) }}
@@ -22,7 +22,7 @@ jobs:
         id: article_endpoint
         env:
           article_url: ${{ on.rss.outputs.link }}
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         with:
           result-encoding: string
           script: |
@@ -33,7 +33,7 @@ jobs:
         with:
           url: ${{ steps.article_endpoint.outputs.result }}
       - name: Twitter username
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         id: twitter_username
         env:
           response: ${{ steps.article_metadata.outputs.data }}
@@ -45,7 +45,7 @@ jobs:
             return response.user.twitter_username;
       - name: Author name from RSS
         id: author_name
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         env:
           rss: ${{ toJSON(on.rss.outputs) }}
         with:
@@ -55,7 +55,7 @@ jobs:
 
             return rss["dc:creator"];
       - name: Author
-        uses: actions/github-script@v6.3.2
+        uses: actions/github-script@v6.3.1
         id: author
         env:
           author_name: ${{ steps.author_name.outputs.result }}

--- a/workflows/this-is-learning-rss.yml
+++ b/workflows/this-is-learning-rss.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RSS categories to hashtags
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         id: hashtags
         env:
           categories: ${{ toJSON(on.rss.outputs.categories) }}
@@ -22,7 +22,7 @@ jobs:
         id: article_endpoint
         env:
           article_url: ${{ on.rss.outputs.link }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         with:
           result-encoding: string
           script: |
@@ -33,7 +33,7 @@ jobs:
         with:
           url: ${{ steps.article_endpoint.outputs.result }}
       - name: Twitter username
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         id: twitter_username
         env:
           response: ${{ steps.article_metadata.outputs.data }}
@@ -45,7 +45,7 @@ jobs:
             return response.user.twitter_username;
       - name: Author name from RSS
         id: author_name
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         env:
           rss: ${{ toJSON(on.rss.outputs) }}
         with:
@@ -55,7 +55,7 @@ jobs:
 
             return rss["dc:creator"];
       - name: Author
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.3.2
         id: author
         env:
           author_name: ${{ steps.author_name.outputs.result }}


### PR DESCRIPTION
# CI
- Update `actions/checkout` to v3
- Update Act to 0.2.32
- Pin `actions/github-script` to v6.3.1 as it appears that Actionsflow and/or Act doesn't support [*environment files*](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/?WT.mc_id=DT-MVP-5003831) yet.

Fixes #20.